### PR TITLE
Improve discoverability on Hugging Face

### DIFF
--- a/archs/DarkIR.py
+++ b/archs/DarkIR.py
@@ -8,7 +8,11 @@ except:
     from archs.arch_model import EBlock, DBlock
     from .arch_util import CustomSequential
 
-class DarkIR(nn.Module):
+
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class DarkIR(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/cidautai/DarkIR", pipeline_tag="image-to-image", tags=["image-super-resolution"]):
     
     def __init__(self, img_channel=3, 
                  width=32, 


### PR DESCRIPTION
Hi @mv-lab and team,

Thanks for this nice work! 

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically:
* load the various DarkIR models using `from_pretrained` (and push them using `push_to_hub`
* track download numbers for your models (similar to models in the Transformers library)
* leverage [safetensors](https://github.com/huggingface/safetensors) for weights serialization
* have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from archs import DarkIR

model = DarkIR.from_pretrained("cidautai/darkir")
```

One can push a trained model as follows:

```python
from archs import DarkIR

model = DarkIR()
state_dict = ...
model.load_state_dict(state_dict)

#one can push a trained model to the hub
model.push_to_hub("cidautai/darkir-example")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub.

Would you be interested in this integration?

Kind regards,

Niels